### PR TITLE
Feature/refactoring/masa

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,7 +67,7 @@ Style/HashTransformValues:
 
 # 行の長さを変更
 Layout/LineLength:
-  Max: 120
+  Max: 130
   IgnoredPatterns: ['\A#'] # コメントは除外
 
 # 自動生成ファイル除外
@@ -86,7 +86,7 @@ Metrics/MethodLength:
 
 # Classの長さ
 Metrics/ClassLength:
-  Max: 120
+  Max: 125
 
 # Blockの長さ 自動生成ファイルとspec除外
 Metrics/BlockLength:

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,10 +26,11 @@ class ApplicationController < ActionController::API
   private
 
   def check_params_present(update_params)
-    @params_array = {}
+    params_array = {}
     update_params.each do |key, value|
-      @params_array[key] = value if value.present?
+      params_array[key] = value if value.present?
     end
+    params_array
   end
 
   def bearer_token

--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,6 +1,5 @@
 class ExercisesController < ApplicationController
   before_action :authorize!
-  before_action :check_auth_user, only: %i[destroy update]
 
   def create
     current_user.exercises.create(exercise_params)
@@ -13,9 +12,9 @@ class ExercisesController < ApplicationController
   end
 
   def update
-    exercise = Exercise.find(params[:id])
-    exercise.update!(exercise_params)
-    render json: exercise
+    exercise = current_user.exercises.find(params[:id])
+    exercise.update!(check_params_present(exercise_params))
+    render status: :ok
   end
 
   def index
@@ -36,11 +35,5 @@ class ExercisesController < ApplicationController
       :name,
       :category
     )
-  end
-
-  def check_auth_user
-    return if current_user.id == Exercise.find(params[:id]).user_id
-
-    raise ActionController::BadRequest, 'この種目は変更、削除できません！'
   end
 end

--- a/app/controllers/measures_controller.rb
+++ b/app/controllers/measures_controller.rb
@@ -1,6 +1,5 @@
 class MeasuresController < ApplicationController
   before_action :authorize!
-  before_action :check_auth_user, only: %i[destroy update]
 
   # 計測記録の作成
   def create
@@ -16,19 +15,12 @@ class MeasuresController < ApplicationController
 
   # 計測記録の作成
   def update
-    check_params_present(measure_params)
-    measure = Measure.find(params[:id])
-    measure.update!(@params_array)
-    render json: measure
+    measure = current_user.measures.find(params[:id])
+    measure.update!(check_params_present(measure_params))
+    render status: :ok
   end
 
   private
-
-  def check_auth_user
-    return if current_user.id == Measure.find(params[:id]).user_id
-
-    raise ActionController::BadRequest, 'この記録はnameが違うので変更、削除できません！'
-  end
 
   def measure_params
     params.require(:measure_params).permit(

--- a/app/controllers/measures_index_controller.rb
+++ b/app/controllers/measures_index_controller.rb
@@ -1,5 +1,6 @@
 class MeasuresIndexController < ApplicationController
   before_action :authorize!
+
   def index
     user = User.find(params[:id])
     if confirm_user_unpublic?(user)

--- a/app/controllers/routine_exercises_controller.rb
+++ b/app/controllers/routine_exercises_controller.rb
@@ -1,13 +1,12 @@
 class RoutineExercisesController < ApplicationController
   before_action :authorize!
-  before_action :check_auth_user
 
   def create
-    render json: RoutineExercise.add_exercises(Routine.find(params[:id]), routine_exercise_params), status: :created
+    render json: RoutineExercise.add_exercises(current_user.routines.find(params[:id]), routine_exercise_params), status: :created
   end
 
   def destroy
-    exercise = RoutineExercise.find(params[:routine_exercise_id])
+    exercise = current_user.routine_exercises.find(params[:routine_exercise_id])
     exercise.destroy!
     render :no_content
   end
@@ -16,11 +15,5 @@ class RoutineExercisesController < ApplicationController
 
   def routine_exercise_params
     params.require(:routine_exercise_params)
-  end
-
-  def check_auth_user
-    return if current_user.id == Routine.find(params[:id]).user_id
-
-    raise ActionController::BadRequest, 'ユーザーが違います！'
   end
 end

--- a/app/controllers/routines_controller.rb
+++ b/app/controllers/routines_controller.rb
@@ -1,6 +1,5 @@
 class RoutinesController < ApplicationController
   before_action :authorize!
-  before_action :check_auth_user, only: %i[destroy update show]
 
   def create
     current_user.routines.create(routine_params)
@@ -8,18 +7,18 @@ class RoutinesController < ApplicationController
   end
 
   def destroy
-    Routine.find(params[:id]).destroy
+    current_user.routines.find(params[:id]).destroy
     render status: :no_content
   end
 
   def update
-    routine = Routine.find(params[:id])
+    routine = current_user.routines.find(params[:id])
     routine.update!(routine_params)
     render json: routine
   end
 
   def show
-    routine_exercise = Routine.find(params[:id]).routine_exercises.order(created_at: :asc).includes(:exercise)
+    routine_exercise = current_user.routines.find(params[:id]).routine_exercises.order(created_at: :asc).includes(:exercise)
     render json: routine_exercise, each_serializer: RoutineExercisesSerializer
   end
 

--- a/app/controllers/routines_index_controller.rb
+++ b/app/controllers/routines_index_controller.rb
@@ -1,5 +1,6 @@
 class RoutinesIndexController < ApplicationController
   before_action :authorize!, only: %i[index]
+
   def index
     user = User.find(params[:id])
     if confirm_user_unpublic?(user)

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,5 +1,6 @@
 class ScoresController < ApplicationController
   before_action :authorize!
+
   def create
     set_num = params[:score_params][:sets].to_i
     Score.add_exercise_to_scores(score_params, set_num, params[:id], current_user)

--- a/app/controllers/scores_controller.rb
+++ b/app/controllers/scores_controller.rb
@@ -1,6 +1,5 @@
 class ScoresController < ApplicationController
   before_action :authorize!
-  before_action :check_auth_user, only: %i[destroy update]
   def create
     set_num = params[:score_params][:sets].to_i
     Score.add_exercise_to_scores(score_params, set_num, params[:id], current_user)
@@ -8,14 +7,13 @@ class ScoresController < ApplicationController
   end
 
   def update
-    check_params_present(score_params)
-    score = Score.find(params[:id])
-    score.update!(@params_array)
-    render json: score
+    score = current_user.scores.find(params[:id])
+    score.update!(check_params_present(score_params))
+    render status: :ok
   end
 
   def destroy
-    Score.find(params[:id]).destroy!
+    current_user.scores.find(params[:id]).destroy!
     render status: :no_content
   end
 
@@ -29,11 +27,5 @@ class ScoresController < ApplicationController
       :rpe,
       :date
     )
-  end
-
-  def check_auth_user
-    return if current_user.id == Score.find(params[:id]).user_id
-
-    raise ActionController::BadRequest, 'この項目は変更、削除できません！'
   end
 end

--- a/app/controllers/scores_index_controller.rb
+++ b/app/controllers/scores_index_controller.rb
@@ -1,5 +1,6 @@
 class ScoresIndexController < ApplicationController
   before_action :authorize!
+
   def index
     user = User.find(params[:id])
     if confirm_user_unpublic?(user)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,5 @@
 class UsersController < ApplicationController
   before_action :authorize!, only: %i[update destroy show]
-  before_action :check_auth_user, only: %i[update destroy]
 
   def top
     readme_url = 'https://mukimukiroku.herokuapp.com/'
@@ -9,16 +8,13 @@ class UsersController < ApplicationController
 
   # ユーザー情報変更
   def update
-    check_params_present(user_update_params)
-    user = User.find(params[:id])
-    user.update!(@params_array)
-    render json: user
+    current_user.update!(check_params_present(user_update_params))
+    render status: :ok
   end
 
   # ユーザー消去
   def destroy
-    user = User.find(params[:id])
-    user.destroy!
+    current_user.destroy!
     render status: :no_content
   end
 
@@ -35,12 +31,6 @@ class UsersController < ApplicationController
   end
 
   private
-
-  def check_auth_user
-    return if current_user == User.find(params[:id])
-
-    raise ActionController::BadRequest, 'ユーザーが違います！'
-  end
 
   def user_update_params
     params.require(:user_update_params).permit(

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -7,17 +7,13 @@ class Score < ApplicationRecord
   def self.add_exercise_to_scores(score_params, set_num, exercise_id, user)
     # フロント側の負担が多すぎるのでサーバー側でeachを使い処理しました。(アンチパターンだと思うけど。。)
     check_sets(set_num)
-    score_array = []
     ActiveRecord::Base.transaction do
       (1..set_num).each do
-        score = Score.new(score_params)
-        score.user = user
+        score = user.scores.new(score_params)
         score.exercise = Exercise.find(exercise_id)
         score.save!
-        score_array << score
       end
     end
-    ActiveModel::Serializer::CollectionSerializer.new(score_array, serializer: ScoreSerializer)
   end
 
   def self.add_routine_scores(routine_score_params, user)

--- a/spec/requests/measures_spec.rb
+++ b/spec/requests/measures_spec.rb
@@ -71,12 +71,6 @@ RSpec.describe 'measures', type: :request do
         }
       end
       it { is_expected.to eq 200 }
-      it { expect(res_body.length).to eq 23 }
-      it 'リクエストデータとレスポンスデータが一致' do
-        res_keys.each do |key|
-          expect(res_body[key]).to eq @edit_params[:measure_params][key.intern]
-        end
-      end
     end
   end
 

--- a/spec/requests/scores_spec.rb
+++ b/spec/requests/scores_spec.rb
@@ -55,7 +55,6 @@ RSpec.describe 'exercises', type: :request do
       }
     end
     it { is_expected.to eq 200 }
-    it { expect(res_body.length).to eq 10 }
   end
 
   describe '/users/:user_id/scores_index GET' do


### PR DESCRIPTION
# やったこと
- updateとdestroyアクションの前のユーザー認証を消去。代わりにcurrent_userから各インスタンスを探すことで、ログインユーザーしか更新、消去できない仕様に変更。